### PR TITLE
Mise à jour auto du fichier de tâches

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,6 +55,14 @@ function saveStatuses(dateStr, statuses) {
     localStorage.setItem('tasks_' + dateStr, JSON.stringify(statuses));
 }
 
+function updateServer(dateStr, statuses) {
+    fetch('/update', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ date: dateStr, statuses })
+    });
+}
+
 function render() {
     const dateStr = formatDate(currentDate);
     document.getElementById('current-date').textContent = dateStr;
@@ -71,6 +79,7 @@ function render() {
         checkbox.addEventListener('change', () => {
             statuses[i] = checkbox.checked;
             saveStatuses(dateStr, statuses);
+            updateServer(dateStr, statuses);
         });
         const label = document.createElement('label');
         label.htmlFor = 'task_' + i;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "daily-task-app",
+  "version": "1.0.0",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,43 @@
+const express = require('express');
+const fs = require('fs');
+const path = require('path');
+const tasksData = require('./tasks.json');
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+app.use(express.json());
+app.use(express.static(__dirname));
+
+app.post('/update', (req, res) => {
+    const { date, statuses } = req.body;
+    if (!date || !Array.isArray(statuses)) {
+        return res.status(400).json({ success: false, message: 'Invalid data' });
+    }
+
+    const filePath = path.join(__dirname, 'daily_tasks.json');
+    let data;
+    try {
+        data = JSON.parse(fs.readFileSync(filePath));
+    } catch (err) {
+        data = { jours: [] };
+    }
+
+    let jour = data.jours.find(j => j.date === date);
+    if (!jour) {
+        jour = { date, taches: tasksData.tasks.map(n => ({ nom: n, fait: false })) };
+        data.jours.push(jour);
+    }
+
+    jour.taches.forEach((t, i) => {
+        if (i < statuses.length) {
+            t.fait = statuses[i];
+        }
+    });
+
+    fs.writeFileSync(filePath, JSON.stringify(data, null, 2));
+    res.json({ success: true });
+});
+
+app.listen(PORT, () => {
+    console.log(`Serveur lancé sur le port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- ajouter `updateServer` pour envoyer l'état des tâches au serveur
- créer un serveur Express (`server.js`) pour mettre à jour `daily_tasks.json`
- ajouter un `package.json` minimal

## Testing
- `node server.js` *(échoue: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_6849387c7ddc832db16f990b0442f4f1