### PR TITLE
Améliore la navigation et déplace l'export/import

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,17 +93,24 @@
             background: var(--card);
             display: flex;
             justify-content: space-around;
-            padding: 8px 0;
+            padding: 10px 0 5px;
             border-top: 1px solid #aaa;
+            box-shadow: 0 -2px 5px rgba(0,0,0,0.3);
+            z-index: 1000;
         }
         .bottom-nav a {
             color: var(--fg);
             text-decoration: none;
-            font-size: 1.4em;
+            font-size: 1.2em;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
         }
-        #controls {
-            text-align: center;
-            margin-bottom: 20px;
+        .bottom-nav a span {
+            font-size: 0.7em;
+        }
+        .bottom-nav a.active {
+            color: var(--accent);
         }
         /* Progress bar */
         #progress-container {
@@ -164,15 +171,11 @@
     <button id="next">Suivant</button>
 </div>
 <div id="progress-container"><div id="progress-bar"></div><span id="progress-text"></span></div>
-<div id="controls">
-    <button id="export">Exporter</button>
-    <input type="file" id="import" accept="application/json">
-</div>
 <div id="tasks"></div>
 <nav class="bottom-nav">
-    <a href="index.html"><i class="fas fa-home"></i></a>
-    <a href="sport.html"><i class="fas fa-futbol"></i></a>
-    <a href="stats.html"><i class="fas fa-chart-bar"></i></a>
+    <a href="index.html"><i class="fas fa-home"></i><span>Accueil</span></a>
+    <a href="sport.html"><i class="fas fa-futbol"></i><span>Sport</span></a>
+    <a href="stats.html"><i class="fas fa-chart-bar"></i><span>Stats</span></a>
 </nav>
 <script>
 const categories = {
@@ -280,33 +283,6 @@ function render(){
     document.getElementById('progress-bar').style.width = percent+"%";
     document.getElementById('progress-text').textContent = `${doneCount}/${total}`;
 }
-function exportData(){
-    const data={tasks:{},seriesRecords:JSON.parse(localStorage.getItem('series_records')||'{}')};
-    for(let i=0;i<localStorage.length;i++){
-        const key=localStorage.key(i);
-        if(key.startsWith('tasks_')){data.tasks[key.substring(6)]=JSON.parse(localStorage.getItem(key));}
-    }
-    const blob=new Blob([JSON.stringify(data,null,2)],{type:'application/json'});
-    const a=document.createElement('a');
-    a.href=URL.createObjectURL(blob);
-    a.download='suivi.json';
-    a.click();
-}
-function importData(e){
-    const f=e.target.files[0];
-    if(!f)return;
-    const r=new FileReader();
-    r.onload=ev=>{
-        try{
-            const data=JSON.parse(ev.target.result);
-            if(data.seriesRecords){localStorage.setItem('series_records',JSON.stringify(data.seriesRecords));}
-            if(data.tasks){for(const [d,s] of Object.entries(data.tasks)){localStorage.setItem('tasks_'+d,JSON.stringify(s));}}
-            alert('Import réussi');
-            render();
-        }catch(err){alert('Erreur lors de l\'import');}
-    };
-    r.readAsText(f);
-}
 function setThemeIcon(th){
     document.getElementById('toggle-theme').innerHTML = th==='dark' ? '<i class="fas fa-moon"></i>' : '<i class="fas fa-sun"></i>';
 }
@@ -330,8 +306,11 @@ document.getElementById('toggle-theme').addEventListener('click',()=>{
     localStorage.setItem('theme',next);
     setThemeIcon(next);
 });
-document.getElementById('export').addEventListener('click',exportData);
-document.getElementById('import').addEventListener('change',importData);
+document.querySelectorAll('.bottom-nav a').forEach(a=>{
+    if(a.getAttribute('href')===location.pathname.split('/').pop()){
+        a.classList.add('active');
+    }
+});
 if('serviceWorker' in navigator){navigator.serviceWorker.register('service-worker.js');}
 </script>
 </body>

--- a/sport.html
+++ b/sport.html
@@ -34,8 +34,10 @@
         .session.done { background:#4caf50; color:#fff; }
         .session span { flex:1; }
         dialog form { display:flex; flex-direction:column; gap:8px; }
-        .bottom-nav { position:fixed; bottom:0; left:0; right:0; background:var(--card); display:flex; justify-content:space-around; padding:8px 0; border-top:1px solid #aaa; }
-        .bottom-nav a { color:var(--fg); text-decoration:none; font-size:1.4em; }
+        .bottom-nav { position:fixed; bottom:0; left:0; right:0; background:var(--card); display:flex; justify-content:space-around; padding:10px 0 5px; border-top:1px solid #aaa; box-shadow:0 -2px 5px rgba(0,0,0,0.3); z-index:1000; }
+        .bottom-nav a { color:var(--fg); text-decoration:none; font-size:1.2em; display:flex; flex-direction:column; align-items:center; }
+        .bottom-nav a span { font-size:0.7em; }
+        .bottom-nav a.active { color:var(--accent); }
     </style>
 </head>
 <body>
@@ -56,9 +58,9 @@
     </form>
 </dialog>
 <nav class="bottom-nav">
-    <a href="index.html"><i class="fas fa-home"></i></a>
-    <a href="sport.html"><i class="fas fa-futbol"></i></a>
-    <a href="stats.html"><i class="fas fa-chart-bar"></i></a>
+    <a href="index.html"><i class="fas fa-home"></i><span>Accueil</span></a>
+    <a href="sport.html"><i class="fas fa-futbol"></i><span>Sport</span></a>
+    <a href="stats.html"><i class="fas fa-chart-bar"></i><span>Stats</span></a>
 </nav>
 <script>
 const categories = {
@@ -169,6 +171,11 @@ document.getElementById('toggle-theme').addEventListener('click',()=>{
     document.documentElement.setAttribute('data-theme',next);
     localStorage.setItem('theme',next);
     setThemeIcon(next);
+});
+document.querySelectorAll('.bottom-nav a').forEach(a=>{
+    if(a.getAttribute('href')===location.pathname.split('/').pop()){
+        a.classList.add('active');
+    }
 });
 initTheme();
 render();

--- a/stats.html
+++ b/stats.html
@@ -13,17 +13,24 @@
         #toggle-theme{position:absolute;right:16px;top:0;background:transparent;border:none;font-size:1.2em;}
         #stats{width:95%;max-width:500px;margin:0 auto;}
         .task{background:var(--card);margin:4px 0;padding:8px 12px;border-radius:10px;display:flex;justify-content:space-between;}
-        .bottom-nav{position:fixed;bottom:0;left:0;right:0;background:var(--card);display:flex;justify-content:space-around;padding:8px 0;border-top:1px solid #aaa;}
-        .bottom-nav a{color:var(--fg);text-decoration:none;font-size:1.4em;}
+        .bottom-nav{position:fixed;bottom:0;left:0;right:0;background:var(--card);display:flex;justify-content:space-around;padding:10px 0 5px;border-top:1px solid #aaa;box-shadow:0 -2px 5px rgba(0,0,0,0.3);z-index:1000;}
+        .bottom-nav a{color:var(--fg);text-decoration:none;font-size:1.2em;display:flex;flex-direction:column;align-items:center;}
+        .bottom-nav a span{font-size:0.7em;}
+        .bottom-nav a.active{color:var(--accent);}
+        #controls{text-align:center;margin-bottom:20px;}
     </style>
 </head>
 <body>
 <h1>Statistiques <button id="toggle-theme"><i class="fas fa-moon"></i></button></h1>
+<div id="controls">
+    <button id="export">Exporter</button>
+    <input type="file" id="import" accept="application/json">
+</div>
 <div id="stats"></div>
 <nav class="bottom-nav">
-    <a href="index.html"><i class="fas fa-home"></i></a>
-    <a href="sport.html"><i class="fas fa-futbol"></i></a>
-    <a href="stats.html"><i class="fas fa-chart-bar"></i></a>
+    <a href="index.html"><i class="fas fa-home"></i><span>Accueil</span></a>
+    <a href="sport.html"><i class="fas fa-futbol"></i><span>Sport</span></a>
+    <a href="stats.html"><i class="fas fa-chart-bar"></i><span>Stats</span></a>
 </nav>
 <script>
 const categories={
@@ -47,6 +54,33 @@ function calculateSeries(index){
 function getRecord(task){
     const records=JSON.parse(localStorage.getItem('series_records')||'{}');
     return records[task]||0;
+}
+function exportData(){
+    const data={tasks:{},seriesRecords:JSON.parse(localStorage.getItem('series_records')||'{}')};
+    for(let i=0;i<localStorage.length;i++){
+        const key=localStorage.key(i);
+        if(key.startsWith('tasks_')){data.tasks[key.substring(6)]=JSON.parse(localStorage.getItem(key));}
+    }
+    const blob=new Blob([JSON.stringify(data,null,2)],{type:'application/json'});
+    const a=document.createElement('a');
+    a.href=URL.createObjectURL(blob);
+    a.download='suivi.json';
+    a.click();
+}
+function importData(e){
+    const f=e.target.files[0];
+    if(!f)return;
+    const r=new FileReader();
+    r.onload=ev=>{
+        try{
+            const data=JSON.parse(ev.target.result);
+            if(data.seriesRecords){localStorage.setItem('series_records',JSON.stringify(data.seriesRecords));}
+            if(data.tasks){for(const [d,s] of Object.entries(data.tasks)){localStorage.setItem('tasks_'+d,JSON.stringify(s));}}
+            alert('Import réussi');
+            render();
+        }catch(err){alert('Erreur lors de l\'import');}
+    };
+    r.readAsText(f);
 }
 function render(){
     const container=document.getElementById('stats');
@@ -73,6 +107,13 @@ document.getElementById('toggle-theme').addEventListener('click',()=>{
     document.documentElement.setAttribute('data-theme',next);
     localStorage.setItem('theme',next);
     setThemeIcon(next);
+});
+document.getElementById('export').addEventListener('click',exportData);
+document.getElementById('import').addEventListener('change',importData);
+document.querySelectorAll('.bottom-nav a').forEach(a=>{
+    if(a.getAttribute('href')===location.pathname.split('/').pop()){
+        a.classList.add('active');
+    }
 });
 initTheme();
 render();


### PR DESCRIPTION
## Résumé
- rend la barre de navigation plus esthétique et la garde visible
- met en surbrillance la page active dans le menu
- déplace les boutons d'export/import dans `stats.html`

## Tests
- `npm test` *(échoue : script absent)*

------
https://chatgpt.com/codex/tasks/task_e_68499631f60c832dacd7919c3827fba4