### PR TITLE
Fix navigation highlight on root page

### DIFF
--- a/index.html
+++ b/index.html
@@ -306,8 +306,9 @@ document.getElementById('toggle-theme').addEventListener('click',()=>{
     localStorage.setItem('theme',next);
     setThemeIcon(next);
 });
+const currentPage = location.pathname.split('/').pop() || 'index.html';
 document.querySelectorAll('.bottom-nav a').forEach(a=>{
-    if(a.getAttribute('href')===location.pathname.split('/').pop()){
+    if(a.getAttribute('href')===currentPage){
         a.classList.add('active');
     }
 });

--- a/sport.html
+++ b/sport.html
@@ -172,8 +172,9 @@ document.getElementById('toggle-theme').addEventListener('click',()=>{
     localStorage.setItem('theme',next);
     setThemeIcon(next);
 });
+const currentPage = location.pathname.split('/').pop() || 'index.html';
 document.querySelectorAll('.bottom-nav a').forEach(a=>{
-    if(a.getAttribute('href')===location.pathname.split('/').pop()){
+    if(a.getAttribute('href')===currentPage){
         a.classList.add('active');
     }
 });

--- a/stats.html
+++ b/stats.html
@@ -110,8 +110,9 @@ document.getElementById('toggle-theme').addEventListener('click',()=>{
 });
 document.getElementById('export').addEventListener('click',exportData);
 document.getElementById('import').addEventListener('change',importData);
+const currentPage = location.pathname.split('/').pop() || 'index.html';
 document.querySelectorAll('.bottom-nav a').forEach(a=>{
-    if(a.getAttribute('href')===location.pathname.split('/').pop()){
+    if(a.getAttribute('href')===currentPage){
         a.classList.add('active');
     }
 });


### PR DESCRIPTION
## Summary
- handle trailing slash in the nav highlight script for all HTML pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68499922b1ec832d817da4493da47364