### PR TITLE
Adoucit mode sombre et couleur de bouton

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,5 +4,5 @@
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#ffffff",
-  "theme_color": "#ff6600"
+  "theme_color": "#b39ddb"
 }

--- a/style.css
+++ b/style.css
@@ -3,16 +3,16 @@
     --bg: #f6f8fa;
     --fg: #333333;
     --card: #ffffff;
-    --accent: #ff6600;
-    --accent2: #00cc99;
+    --accent: #b39ddb;
+    --accent2: #a8d5e2;
 }
 [data-theme="dark"] {
     /* Palette sombre épurée */
-    --bg: #121212;
+    --bg: #2b2b33;
     --fg: #e0e0e0;
-    --card: #1f1f1f;
-    --accent: #ff9933;
-    --accent2: #33cc99;
+    --card: #3a3a43;
+    --accent: #cfb1e7;
+    --accent2: #89c9b8;
 }
 body {
     font-family: 'Poppins', 'Roboto', Arial, sans-serif;


### PR DESCRIPTION
## Summary
- adoucit les couleurs du thème sombre pour éviter un noir trop présent
- remplace l'orange des boutons par une teinte pastel
- met à jour la couleur du thème dans le manifest

## Testing
- `npm test` *(échoue : script manquant)*

------
https://chatgpt.com/codex/tasks/task_e_684c154e8c1c832dacbce9ba49ffb3a5