### PR TITLE
Change accent color and fix checkbox sizing

### DIFF
--- a/style.css
+++ b/style.css
@@ -3,15 +3,16 @@
     --bg: #f6f8fa;
     --fg: #333333;
     --card: #ffffff;
-    --accent: #b39ddb;
+    --accent: #8ee39b;
     --accent2: #a8d5e2;
+    --checkbox-size: 24px;
 }
 [data-theme="dark"] {
     /* Palette sombre épurée */
     --bg: #2b2b33;
     --fg: #e0e0e0;
     --card: #3a3a43;
-    --accent: #cfb1e7;
+    --accent: #7acc7d;
     --accent2: #89c9b8;
 }
 body {
@@ -168,16 +169,14 @@ h1 {
 }
 .task input[type="checkbox"] {
     appearance: none;
-    width: 20px;
-    height: 20px;
+    width: var(--checkbox-size);
+    height: var(--checkbox-size);
     border: 2px solid var(--accent);
     border-radius: 4px;
     position: relative;
-    transition: background 0.2s, transform 0.2s;
+    transition: background 0.2s;
     cursor: pointer;
-}
-.task input[type="checkbox"]:active {
-    transform: scale(0.8);
+    flex-shrink: 0;
 }
 .task input[type="checkbox"]:checked {
     background: var(--accent);


### PR DESCRIPTION
## Summary
- update theme accent to a flashy pastel green
- make checkboxes consistently sized

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684c18316ed0832d89deb052247e9a51