### PR TITLE
Réaménagement du menu bas et nouveau bouton Accueil

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,11 +11,11 @@
 </head>
 <body>
 <nav class="side-nav">
-    <a href="index.html"><i class="fas fa-home"></i> Accueil</a>
     <a href="sport.html"><i class="fas fa-futbol"></i> Sport</a>
+    <a href="index.html" class="home-btn"><i class="fas fa-home"></i></a>
     <a href="stats.html"><i class="fas fa-chart-bar"></i> Stats</a>
-    <button id="toggle-theme"><i class="fas fa-moon"></i></button>
 </nav>
+<button id="toggle-theme"><i class="fas fa-moon"></i></button>
 <h1>Tâches du jour</h1>
 <div class="date-navigation">
     <button id="prev"><i class="fas fa-chevron-left"></i></button>

--- a/sport.html
+++ b/sport.html
@@ -17,11 +17,11 @@
 </head>
 <body>
 <nav class="side-nav">
-    <a href="index.html"><i class="fas fa-home"></i> Accueil</a>
     <a href="sport.html"><i class="fas fa-futbol"></i> Sport</a>
+    <a href="index.html" class="home-btn"><i class="fas fa-home"></i></a>
     <a href="stats.html"><i class="fas fa-chart-bar"></i> Stats</a>
-    <button id="toggle-theme"><i class="fas fa-moon"></i></button>
 </nav>
+<button id="toggle-theme"><i class="fas fa-moon"></i></button>
 <h1>Séances de sport</h1>
 <div id="controls">
     <button id="add">Ajouter une séance</button>

--- a/stats.html
+++ b/stats.html
@@ -13,11 +13,11 @@
 </head>
 <body>
 <nav class="side-nav">
-    <a href="index.html"><i class="fas fa-home"></i> Accueil</a>
     <a href="sport.html"><i class="fas fa-futbol"></i> Sport</a>
+    <a href="index.html" class="home-btn"><i class="fas fa-home"></i></a>
     <a href="stats.html"><i class="fas fa-chart-bar"></i> Stats</a>
-    <button id="toggle-theme"><i class="fas fa-moon"></i></button>
 </nav>
+<button id="toggle-theme"><i class="fas fa-moon"></i></button>
 <h1>Statistiques</h1>
 <div id="controls">
     <button id="export">Exporter</button>

--- a/style.css
+++ b/style.css
@@ -42,6 +42,10 @@ h1 {
     align-items: center;
     justify-content: center;
     box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+    position: fixed;
+    right: 20px;
+    bottom: 80px;
+    z-index: 1001;
 }
 .date-navigation {
     display: flex;
@@ -134,11 +138,21 @@ h1 {
     font-weight: bold;
     margin: 0;
 }
+.side-nav a.home-btn {
+    background: var(--accent);
+    color: var(--card);
+    width: 60px;
+    height: 60px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: relative;
+    top: -20px;
+    box-shadow: 0 2px 5px rgba(0,0,0,0.3);
+}
 .side-nav a.active {
     text-decoration: underline;
-}
-.side-nav #toggle-theme {
-    margin-top: 0;
 }
 #progress-container {
     width: 95%;


### PR DESCRIPTION
## Notes
- Suppression du bouton clair/sombre dans la barre de navigation basse
- Ajout d'un bouton Accueil centré, circulaire et mis en valeur
- Nouveau bouton de changement de thème flottant en bas à droite

## Testing
- Aucun test automatisé n'est présent dans le dépôt

------
https://chatgpt.com/codex/tasks/task_e_684c19d67300832daabc8df3cd950103