### PR TITLE
Ajout de commentaires sur les tâches

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,6 +67,13 @@ function loadStatuses(date){
 function saveStatuses(date,statuses){
     localStorage.setItem('tasks_'+date, JSON.stringify(statuses));
 }
+function loadComments(date){
+    const s = localStorage.getItem('comments_'+date);
+    return s?JSON.parse(s):{};
+}
+function saveComments(date,comments){
+    localStorage.setItem('comments_'+date, JSON.stringify(comments));
+}
 function calculateSeries(index,date){
     let count = 0;
     let d = new Date(date);
@@ -86,6 +93,20 @@ function updateRecord(task, count){
 }
 function loadSessions(){
     return JSON.parse(localStorage.getItem('sport_sessions')||'[]');
+}
+function openComment(idx,dateStr){
+    const comments=loadComments(dateStr);
+    const current=comments[idx]||'';
+    const text=prompt('Commentaire pour cette tâche:',current);
+    if(text!==null){
+        if(text.trim()){
+            comments[idx]=text.trim();
+        }else{
+            delete comments[idx];
+        }
+        saveComments(dateStr,comments);
+        render();
+    }
 }
 function renderSessions(dateStr, done){
     const list=document.getElementById('sessions');
@@ -108,6 +129,7 @@ function render(){
     document.getElementById('current-date').textContent = dateStr;
     const sportDay = hasSportSession(dateStr);
     const statuses = loadStatuses(dateStr);
+    const comments = loadComments(dateStr);
     const container = document.getElementById('tasks');
     container.innerHTML = '';
     const total = statuses.length;
@@ -138,9 +160,24 @@ function render(){
             const serieSpan = document.createElement('span');
             serieSpan.className='series';
             serieSpan.textContent = `🔥 ${seriesCount}`;
+
+            let timer;
+            div.addEventListener('pointerdown',e=>{
+                if(e.target.tagName==='INPUT') return;
+                timer=setTimeout(()=>openComment(i,dateStr),600);
+            });
+            div.addEventListener('pointerup',()=>clearTimeout(timer));
+            div.addEventListener('pointerleave',()=>clearTimeout(timer));
+
+            const commentIcon = document.createElement('span');
+            commentIcon.className = 'comment-icon';
+            commentIcon.innerHTML = '<i class="fas fa-comment-dots"></i>';
+            if(!comments[i]) commentIcon.style.visibility='hidden';
+
             div.appendChild(cb);
             div.appendChild(label);
             div.appendChild(serieSpan);
+            div.appendChild(commentIcon);
             catDiv.appendChild(div);
             if(cb.checked) doneCount++;
             idx++;

--- a/style.css
+++ b/style.css
@@ -117,6 +117,11 @@ h1 {
     font-size: 0.8em;
     margin-left: 4px;
 }
+.comment-icon {
+    margin-left: 6px;
+    font-size: 0.9em;
+    color: var(--accent2);
+}
 .side-nav {
     position: fixed;
     bottom: 0;


### PR DESCRIPTION
## Résumé
- ajout de fonctions de gestion des commentaires
- possibilité d'ouvrir une fenêtre de saisie par appui long
- affichage d'une icône si un commentaire est présent
- style dédié à l'icône de commentaire

## Testing
- `npm start` *(échoue : module `express` manquant)*

------
https://chatgpt.com/codex/tasks/task_e_684c1f91cbb4832da3fb80f01274d1f4