### PR TITLE
Ajout du double-clic pour commentaires

### DIFF
--- a/index.html
+++ b/index.html
@@ -168,6 +168,12 @@ function render(){
             });
             div.addEventListener('pointerup',()=>clearTimeout(timer));
             div.addEventListener('pointerleave',()=>clearTimeout(timer));
+            if(window.matchMedia('(pointer: fine)').matches){
+                div.addEventListener('dblclick',e=>{
+                    if(e.target.tagName==='INPUT') return;
+                    openComment(i,dateStr);
+                });
+            }
 
             const commentIcon = document.createElement('span');
             commentIcon.className = 'comment-icon';


### PR DESCRIPTION
## Notes
- Tentative d'exécution `npm test` impossible car aucun script n'est défini.

## Résumé
- prise en charge du double-clic sur PC pour ouvrir la fenêtre de commentaire


------
https://chatgpt.com/codex/tasks/task_e_684c206f86dc832d96da5c5f74ecde61