### PR TITLE
Fix calendrier decalage

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,7 +60,10 @@ const categories = {
 const tasks = Object.values(categories).flat();
 const sportIndex = tasks.indexOf('Sport');
 let currentDate = new Date();
-function formatDate(d){return d.toISOString().split('T')[0];}
+function formatDate(d){
+    // normalise la date pour éviter le décalage lié au fuseau horaire
+    return new Date(d.getTime()-d.getTimezoneOffset()*60000).toISOString().split('T')[0];
+}
 function loadStatuses(date){
     const s = localStorage.getItem('tasks_'+date);
     return s?JSON.parse(s):tasks.map(()=>false);

--- a/stats.html
+++ b/stats.html
@@ -40,7 +40,10 @@ const categories={
 const tasks=Object.values(categories).flat();
 function setThemeIcon(th){document.getElementById('toggle-theme').innerHTML=th==='dark'?'<i class="fas fa-moon"></i>':'<i class="fas fa-sun"></i>';}
 function initTheme(){const th=localStorage.getItem('theme')||'dark';document.documentElement.setAttribute('data-theme',th);setThemeIcon(th);}
-function formatDate(d){return d.toISOString().split('T')[0];}
+function formatDate(d){
+    // normalise la date pour éviter le décalage lié au fuseau horaire
+    return new Date(d.getTime()-d.getTimezoneOffset()*60000).toISOString().split('T')[0];
+}
 function calculateSeries(index){
     let count=0;let d=new Date();
     while(true){


### PR DESCRIPTION
## Notes
- executed `npm test` but no script found

## Summary
- normalise la fonction `formatDate` pour supprimer le décalage horaire
- même correctif appliqué dans `stats.html` et `index.html`


------
https://chatgpt.com/codex/tasks/task_e_684c2cde9834832d8bedf1a6e081f2fe