### PR TITLE
Mise en forme du bouton d'import

### DIFF
--- a/stats.html
+++ b/stats.html
@@ -23,7 +23,8 @@
 <h1>Statistiques</h1>
 <div id="controls">
     <button id="export">Exporter</button>
-    <input type="file" id="import" accept="application/json">
+    <label for="import" id="import-label">Choisir un fichier</label>
+    <input type="file" id="import" accept="application/json" style="display:none">
 </div>
 <div id="calendar"></div>
 <div id="global-rate"></div>

--- a/style.css
+++ b/style.css
@@ -228,6 +228,15 @@ h1 {
     padding: 6px 16px;
     margin: 0 4px;
 }
+#controls label#import-label {
+    background: var(--accent);
+    color: #fff;
+    border: none;
+    border-radius: 20px;
+    padding: 6px 16px;
+    margin: 0 4px;
+    cursor: pointer;
+}
 .stats-category {
     background: var(--card);
     padding: 16px;


### PR DESCRIPTION
## Notes
- aucun test n'existe dans le repo (`npm test` échoue)

## Summary
- cache le champ de sélection de fichier et ajoute un label stylisé
- applique le même style au label d'import qu'au bouton d'export

## Testing
- `npm test` *(échoue : Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_684c2e290a84832d9f852804094e763e